### PR TITLE
Add aarch64 to supported systems in dfx-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '22.11', '23.05' ]
+        channel: [ '23.05' ]
         os: [ ubuntu-latest, macos-latest, macos-14 ]
         include:
           - os: ubuntu-latest
@@ -23,8 +23,6 @@ jobs:
             prefix: nixpkgs
           - channel: '23.05'
             channel-darwin: '23.05-darwin'
-          - channel: '22.11'
-            channel-darwin: '22.11-darwin'
 
     steps:
     - uses: actions/checkout@v3
@@ -53,8 +51,8 @@ jobs:
       fail-fast: false
       matrix:
         project: [ 'motoko', 'ic-no-shell', 'sdk', 'utils' ]
-        channel: [ '22.11', '23.05' ]
-        os: [ ubuntu-latest, macos-latest ]
+        channel: [ '23.05' ]
+        os: [ ubuntu-latest, macos-latest, macos-14 ]
         include:
           - os: ubuntu-latest
             prefix: nixos
@@ -62,10 +60,11 @@ jobs:
           - os: macos-latest
             prefix: nixpkgs
             name: darwin
+          - os: macos-14
+            prefix: nixpkgs
+            name: darwin
           - channel: '23.05'
             channel-darwin: '23.05-darwin'
-          - channel: '22.11'
-            channel-darwin: '22.11-darwin'
 
     steps:
     - name: Maximize build space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             prefix: nixos
           - os: macos-latest
             prefix: nixpkgs
+          - os: macos-14
+            prefix: nixpkgs
           - channel: '23.05'
             channel-darwin: '23.05-darwin'
           - channel: '22.11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         channel: [ '22.11', '23.05' ]
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, macos-14 ]
         include:
           - os: ubuntu-latest
             prefix: nixos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '22.11' ]
-        os: [ ubuntu-latest, macos-latest ]
+        channel: [ '23.05' ]
+        os: [ ubuntu-latest, macos-latest, macos-14 ]
         include:
           - os: ubuntu-latest
             name: linux
@@ -23,8 +23,8 @@ jobs:
           - os: macos-14
             name: darwin
             prefix: nixpkgs
-          - channel: '22.11'
-            channel-darwin: '22.11-darwin'
+          - channel: '23.05'
+            channel-darwin: '23.05-darwin'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
           - os: macos-latest
             name: darwin
             prefix: nixpkgs
+          - os: macos-14
+            name: darwin
+            prefix: nixpkgs
           - channel: '22.11'
             channel-darwin: '22.11-darwin'
 

--- a/dfx-env.nix
+++ b/dfx-env.nix
@@ -5,7 +5,7 @@
 with pkgs;
 let
   ostypes = [ "linux" "darwin" ];
-  archs = [ "x86_64" ];
+  archs = [ "x86_64" "aarch64" ];
   supported-systems =
     builtins.concatMap (arch: builtins.map (os: arch + "-" + os) ostypes) archs;
   binaries = fetchTarball {


### PR DESCRIPTION
Github does not support aarch64 runner VMs. So we have to rely on manual upload effort for now. This poses a security risk. So I'm keeping it as a PR without merging. Please do not expect frequent updates either.