### PR TITLE
Fix motoko compiliation on nixos 22.05 & patch ciborium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - channel: '21.11'
             channel-darwin: '21.11-darwin'
           - channel: '22.05'
-            channel-darwin: '22.05'
+            channel-darwin: '22.05-darwin'
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -63,7 +63,7 @@ jobs:
           - channel: '21.11'
             channel-darwin: '21.11-darwin'
           - channel: '22.05'
-            channel-darwin: '22.05'
+            channel-darwin: '22.05-darwin'
 
     steps:
     - name: Maximize build space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '21.11' '22.05' ]
+        channel: [ '21.11', '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [ 'motoko', 'ic', 'sdk', 'utils' ]
-        channel: [ '21.11' '22.05' ]
+        channel: [ '21.11', '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '21.11' ]
+        channel: [ '21.11' '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -21,6 +21,8 @@ jobs:
             prefix: nixpkgs
           - channel: '21.11'
             channel-darwin: '21.11-darwin'
+          - channel: '22.05'
+            channel-darwin: '22.05'
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -49,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [ 'motoko', 'ic', 'sdk', 'utils' ]
-        channel: [ '21.11' ]
+        channel: [ '21.11' '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -60,6 +62,8 @@ jobs:
             name: darwin
           - channel: '21.11'
             channel-darwin: '21.11-darwin'
+          - channel: '22.05'
+            channel-darwin: '22.05'
 
     steps:
     - name: Maximize build space

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Supported platforms:
 Supported nixpkgs:
 
 - [x] 21.11
-- [ ] 22.05 (a new ocaml version broke motoko compilation)
-- [ ] unstable (same as above)
+- [x] 22.05
+- [ ] unstable
 
 Feature:
 

--- a/ic.nix
+++ b/ic.nix
@@ -69,6 +69,7 @@ let
         cp -r $src ${name}
         echo source root is ${sourceRoot}
         chmod -R u+w -- "$sourceRoot"
+        cd ${name} && patch -p1 < ${./nix/ic-ciborium-0.2.0.patch} && cd ..
         runHook postUnpack
       '';
       sourceRoot = "${name}/rs";
@@ -86,7 +87,7 @@ let
         with darwin.apple_sdk.frameworks; [ CoreServices Foundation Security ]
       else
         [ libunwind ]);
-      cargoSha256 = "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+      cargoSha256 = "sha256-B/1vTMscNSATFK1JzMWE6BAg3OyqRfTQwYhfLAR/9FM="; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/ic.nix
+++ b/ic.nix
@@ -86,7 +86,7 @@ let
         with darwin.apple_sdk.frameworks; [ CoreServices Foundation Security ]
       else
         [ libunwind ]);
-      cargoSha256 = "sha256-0f2S+zO1pRnC8v7GOPMEE68ZQypnIKX+NONpV1CMqIA="; # cargoSha256
+      cargoSha256 = "0000000000000000000000000000000000000000000000000000"; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/motoko.nix
+++ b/motoko.nix
@@ -11,6 +11,24 @@ let
     inherit ocamlPackages;
     inherit (pkgs.stdenv) mkDerivation;
   };
+  # An old version of menhir is required to parse moc grammar!
+  menhirLib = ocamlPackages.menhirLib.overrideAttrs (_: {
+    version = "20211012";
+    src = pkgs.fetchFromGitLab {
+      domain = "gitlab.inria.fr";
+      owner = "fpottier";
+      repo = "menhir";
+      rev = "20211012";
+      sha256 = "08kf5apbv15n2kcr3qhyr3rvsf2lg25ackr3x9kfgiiqc0p3sz40";
+    };
+    useDune2 = true;
+  });
+  menhirSdk = ocamlPackages.menhirSdk.overrideAttrs
+    (_: { inherit (menhirLib) version src useDune2; });
+  menhir = ocamlPackages.menhir.overrideAttrs (_: {
+    inherit (menhirLib) version src useDune2;
+    buildInputs = [ menhirLib menhirSdk ];
+  });
   rtsBuildInputs = with pkgs;
     [
       # pulls in clang (wrapped) and clang-13 (unwrapped)
@@ -44,8 +62,8 @@ let
     ocamlPackages.atdgen
     ocamlPackages.checkseum
     ocamlPackages.findlib
-    ocamlPackages.menhir
-    ocamlPackages.menhirLib
+    menhir
+    menhirLib
     ocamlPackages.cow
     ocamlPackages.num
     ocamlPackages.stdint
@@ -130,14 +148,15 @@ in rec {
     cargoVendorTools = pkgs.rustPlatform.buildRustPackage rec {
       name = "cargo-vendor-tools";
       src = "${sources.motoko}/rts/${name}/";
-      cargoSha256 = "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+      cargoSha256 =
+        "sha256-CrtZQTac95MEbk3uapviLgcQjEt5VUnTOG9fiJXIAU8="; # cargoSha256
     };
 
     # Path to vendor-rust-std-deps, provided by cargo-vendor-tools
     vendorRustStdDeps = "${cargoVendorTools}/bin/vendor-rust-std-deps";
 
     # SHA256 of Rust std deps
-    rustStdDepsHash = "0pssda6sjpw9fby0wrl1502x66k924x9isqdw8lw96jzj6w2xaxw";
+    rustStdDepsHash = "sha256-vKsuuJFfmsQp4g3rmDoRaRrTBSiBZg78colfqY1qWl8=";
 
     # Vendor directory for Rust std deps
     rustStdDeps = pkgs.stdenvNoCC.mkDerivation {

--- a/motoko.nix
+++ b/motoko.nix
@@ -29,6 +29,16 @@ let
     inherit (menhirLib) version src useDune2;
     buildInputs = [ menhirLib menhirSdk ];
   });
+  wasm = ocamlPackages.wasm.overrideAttrs (_: {
+    version = "1.1.1";
+    src = pkgs.fetchFromGitHub {
+      owner = "WebAssembly";
+      repo = "spec";
+      rev = "opam-1.1.1";
+      sha256 = "1kp72yv4k176i94np0m09g10cviqp2pnpm7jmiq6ik7fmmbknk7c";
+    };
+  });
+
   rtsBuildInputs = with pkgs;
     [
       # pulls in clang (wrapped) and clang-13 (unwrapped)
@@ -67,7 +77,7 @@ let
     ocamlPackages.cow
     ocamlPackages.num
     ocamlPackages.stdint
-    ocamlPackages.wasm
+    wasm
     ocamlPackages.vlq
     ocamlPackages.zarith
     ocamlPackages.yojson

--- a/nix/ic-ciborium-0.2.0.patch
+++ b/nix/ic-ciborium-0.2.0.patch
@@ -1,0 +1,52 @@
+diff --git a/rs/rosetta-api/icrc1/Cargo.toml b/rs/rosetta-api/icrc1/Cargo.toml
+index 9e71f5da5..13c80970f 100644
+--- a/rs/rosetta-api/icrc1/Cargo.toml
++++ b/rs/rosetta-api/icrc1/Cargo.toml
+@@ -7,7 +7,7 @@ edition = "2018"
+ 
+ [dependencies]
+ candid = "0.7.10"
+-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
++ciborium = "0.2.0"
+ hex = "0.4.2"
+ ic-base-types = { path = "../../types/base_types" }
+ ic-crypto-sha = { path = "../../crypto/sha" }
+diff --git a/rs/rosetta-api/icrc1/archive/Cargo.toml b/rs/rosetta-api/icrc1/archive/Cargo.toml
+index 12341d96c..df9efb850 100644
+--- a/rs/rosetta-api/icrc1/archive/Cargo.toml
++++ b/rs/rosetta-api/icrc1/archive/Cargo.toml
+@@ -7,7 +7,7 @@ edition = "2018"
+ 
+ [dependencies]
+ candid = "0.7.10"
+-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
++ciborium = "0.2.0"
+ ic-base-types = { path = "../../../types/base_types" }
+ ic-cdk = { version = "0.5.1" }
+ ic-cdk-macros = { version = "0.5.1" }
+diff --git a/rs/rosetta-api/icrc1/ledger/Cargo.toml b/rs/rosetta-api/icrc1/ledger/Cargo.toml
+index ba7edaebd..99330c932 100644
+--- a/rs/rosetta-api/icrc1/ledger/Cargo.toml
++++ b/rs/rosetta-api/icrc1/ledger/Cargo.toml
+@@ -8,7 +8,7 @@ edition = "2018"
+ [dependencies]
+ async-trait = "0.1.53"
+ candid = "0.7.10"
+-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
++ciborium = "0.2.0"
+ hex = "0.4.2"
+ ic-base-types = { path = "../../../types/base_types" }
+ ic-crypto-tree-hash = { path = "../../../crypto/tree_hash" }
+diff --git a/rs/rosetta-api/ledger_canister/Cargo.toml b/rs/rosetta-api/ledger_canister/Cargo.toml
+index be012afec..5bd451f3f 100644
+--- a/rs/rosetta-api/ledger_canister/Cargo.toml
++++ b/rs/rosetta-api/ledger_canister/Cargo.toml
+@@ -9,7 +9,7 @@ edition = "2018"
+ async-trait = "0.1.53"
+ byteorder = "1.4"
+ candid = "0.7.10"
+-ciborium = { git = "https://github.com/enarx/ciborium", rev = "e719537c99b564c3674a56defe53713c702c6f46" }
++ciborium = "0.2.0"
+ comparable = { version = "0.5", features = ["derive"] }
+ crc32fast = "1.2.0"
+ dfn_candid = {path = "../../rust_canisters/dfn_candid"}

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,8 +1,8 @@
 { fetchgit }: {
   ic = fetchgit {
     url = "https://github.com/dfinity/ic"; # master
-    rev = "b4520987d4af25eef72ea1c9e009092babd26ed9";
-    sha256 = "1h3yx77xbv0laqcf9pzs1x18xvnfiak4z7h8rw3gmxbqlh2xc32y";
+    rev = "d1fc232efaa2a5de4380c3cca71d7074d617d848";
+    sha256 = "sha256-TA6YXhU0cpjyLp5AX2VM4pUJEPjJ7DJX3UUnV2bUuZU=";
   };
   icx-proxy = fetchgit {
     url = "https://github.com/dfinity/icx-proxy"; # main

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,13 +1,13 @@
 { fetchgit }: {
   ic = fetchgit {
     url = "https://github.com/dfinity/ic"; # master
-    rev = "25f28745116689641513477464e2f997b61ac553";
-    sha256 = "0z6iqzv7l5ppsm40izr6fgyqppgc0crdrc756nfa30hpd8z6yh8n";
+    rev = "b4520987d4af25eef72ea1c9e009092babd26ed9";
+    sha256 = "1h3yx77xbv0laqcf9pzs1x18xvnfiak4z7h8rw3gmxbqlh2xc32y";
   };
   icx-proxy = fetchgit {
     url = "https://github.com/dfinity/icx-proxy"; # main
-    rev = "5e15a91cd152d3faa869be3f7ee34202b7b82e8c";
-    sha256 = "0ghb74xf13dx4z9my4bbvvfdv21hnrszr1dl48afa4q6rwk30y35";
+    rev = "76b4159d452e0c9295603a3db99ebd4b282d085e";
+    sha256 = "0hb39b2hr5xj3k82v3hp9h2xj42dlxxddj1rxk43cahxwk70isi6";
   };
   libtommath = fetchgit {
     url = "https://github.com/libtom/libtommath"; # master
@@ -16,13 +16,13 @@
   };
   motoko = fetchgit {
     url = "https://github.com/dfinity/motoko"; # master
-    rev = "13f8a6693b7ca0d02899ae91b40c9dd17a3b8f36";
-    sha256 = "0chxh32xjxvqljbnyykw550w72l7kiava9xbgd2ccnkjfyh84bsy";
+    rev = "82146bd54e48dcb4fa7ab05d819461935c9a0a1a";
+    sha256 = "0dls8cii1rlwnydfjf0xqng8x8h01l71mywq02wkiqavvpsyicgj";
   };
   motoko-base = fetchgit {
     url = "https://github.com/dfinity/motoko-base"; # next-moc
-    rev = "b7ddafd36e483f8af7083e5cb46cf81e57667957";
-    sha256 = "1py0vfww4l10yh80l3hr67bwjllc4pmnyi54jwczk9aa1ffny0y3";
+    rev = "7ca5b2c83dacd88ccfc543b297b870b91b730362";
+    sha256 = "1pnch81lwcs0xfsih1gmzdkqackj97y3mz1cmrd0a2csinvxkmlx";
   };
   musl-wasi = fetchgit {
     url = "https://github.com/WebAssembly/wasi-libc"; # main
@@ -31,8 +31,8 @@
   };
   sdk = fetchgit {
     url = "https://github.com/dfinity/sdk"; # master
-    rev = "860ed9980702ba96c7b199c7938c41b0eb416688";
-    sha256 = "069aahi8bnvjzr5k4xy9v0hjn00vpwg4jfbzmvysy118yj4s5lb2";
+    rev = "b2927b8eeb1a26bea6f4008c4a662f2d6af499b0";
+    sha256 = "1m89yrallh1ba0jf3zglgn11kfkkvl2y2z8vvin3j2r9vyp7q1b7";
   };
   lmdb = fetchgit {
     url = "https://git.openldap.org/openldap/openldap.git"; # mdb.master

--- a/sdk.nix
+++ b/sdk.nix
@@ -8,7 +8,7 @@ let
   dfx = rustPlatform.buildRustPackage {
     name = "dfx";
     inherit src;
-    cargoSha256 = "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    cargoSha256 = "jSFl5XhHe5cXb58UHlfLRh1LttWqDU1XLamxR51X3Lk"; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ pkg-config ];
     preConfigure = ''

--- a/sdk.nix
+++ b/sdk.nix
@@ -8,7 +8,7 @@ let
   dfx = rustPlatform.buildRustPackage {
     name = "dfx";
     inherit src;
-    cargoSha256 = "sha256-c50LYYj9TTPJ7DR3nr5nrHQjrJ8Q+4bw4+AnpvJDAao="; # cargoSha256
+    cargoSha256 = "0000000000000000000000000000000000000000000000000000"; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ pkg-config ];
     preConfigure = ''

--- a/sdk.nix
+++ b/sdk.nix
@@ -8,7 +8,7 @@ let
   dfx = rustPlatform.buildRustPackage {
     name = "dfx";
     inherit src;
-    cargoSha256 = "jSFl5XhHe5cXb58UHlfLRh1LttWqDU1XLamxR51X3Lk"; # cargoSha256
+    cargoSha256 = "sha256-jSFl5XhHe5cXb58UHlfLRh1LttWqDU1XLamxR51X3Lk"; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ pkg-config ];
     preConfigure = ''

--- a/utils.nix
+++ b/utils.nix
@@ -19,13 +19,13 @@ let
     };
 in rec {
   icx-proxy =
-    mkDrv "icx-proxy" "sha256-RkO9vjpJACsEZjgfQ57/c73EObJRB2l/5R3zt08u+WA="; # cargoSha256
+    mkDrv "icx-proxy" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   vessel =
-    mkDrv "vessel" "sha256-YKLDYEdIkMFtM5ZTOzRJxXi3YAmGtzH+2kPyLSHV1Ok="; # cargoSha256
+    mkDrv "vessel" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   ic-repl =
-    mkDrv "ic-repl" "sha256-r1E7nWTgPOXO/XQFzWPg1aiPMOKqupIS0//0cY/TyHE="; # cargoSha256
+    mkDrv "ic-repl" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   candid =
-    mkDrv "candid" "sha256-KejEkKUUPyZvgGp/KHcVxCpzy17cAfABUw4FLIu9N8c="; # cargoSha256
+    mkDrv "candid" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
 
   shell = icx-proxy;
 }

--- a/utils.nix
+++ b/utils.nix
@@ -19,13 +19,13 @@ let
     };
 in rec {
   icx-proxy =
-    mkDrv "icx-proxy" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    mkDrv "icx-proxy" "sha256-vprJ3E8vv+AWrEiajMQLVB2wTlckFYQeDQnDDoft2EI="; # cargoSha256
   vessel =
-    mkDrv "vessel" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    mkDrv "vessel" "sha256-YKLDYEdIkMFtM5ZTOzRJxXi3YAmGtzH+2kPyLSHV1Ok="; # cargoSha256
   ic-repl =
-    mkDrv "ic-repl" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    mkDrv "ic-repl" "sha256-r1E7nWTgPOXO/XQFzWPg1aiPMOKqupIS0//0cY/TyHE="; # cargoSha256
   candid =
-    mkDrv "candid" "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    mkDrv "candid" "sha256-KejEkKUUPyZvgGp/KHcVxCpzy17cAfABUw4FLIu9N8c="; # cargoSha256
 
   shell = icx-proxy;
 }


### PR DESCRIPTION
* Update sources.
* Pin older versions of menhir and wasm to avoid motoko compilation failure.
* Use a patch to fix ciborium version in IC to avoid `cargo vendor` error.