### PR TITLE
Fix libiconv error when building IC

### DIFF
--- a/ic.nix
+++ b/ic.nix
@@ -101,7 +101,6 @@ let
         "-lstatic=lmdb"
         "-lstatic=z"
       ] ++ lib.optionals stdenv.isDarwin [
-        "-Lnative=${libiconv-static.out}/lib"
         "-L=${libiconv-static.out}/lib"
         "-lstatic=iconv"
       ];

--- a/ic.nix
+++ b/ic.nix
@@ -102,6 +102,7 @@ let
         "-lstatic=z"
       ] ++ lib.optionals stdenv.isDarwin [
         "-Lnative=${libiconv-static.out}/lib"
+        "-L=${libiconv-static.out}/lib"
         "-lstatic=iconv"
       ];
 

--- a/ic.nix
+++ b/ic.nix
@@ -101,7 +101,7 @@ let
         "-lstatic=lmdb"
         "-lstatic=z"
       ] ++ lib.optionals stdenv.isDarwin [
-        "-L=${libiconv-static.out}/lib"
+        "-Lall=${libiconv-static.out}/lib"
         "-lstatic=iconv"
       ];
 


### PR DESCRIPTION
## The problem

On my m1 mac, In `ic`'s `rs/sns/init` directory, I get an error where the linker isn't able to find iconv:

```
[nix-shell:~/dev/work/dfinity/ic/rs/sns/init]$ cargo build
   Compiling syn v1.0.96
   Compiling libc v0.2.126
   Compiling serde_json v1.0.79
   Compiling log v0.4.14
   Compiling slog v2.7.0
   Compiling ledger-canister v0.8.0 (/Users/andrepopovitch/dev/work/dfinity/ic/rs/rosetta-api/ledger_canister)
   Compiling futures-core v0.3.21
   Compiling futures-channel v0.3.21
   Compiling num-bigint-dig v0.8.1
   Compiling futures-util v0.3.21
error: linking with `cc` failed: exit status: 1
  |
  = note: "cc" "-arch" "arm64" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.0.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.1.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.10.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.11.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.12.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.13.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.14.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.15.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.2.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.3.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.4.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.5.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.6.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.7.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.8.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.build_script_build.5675bdc7-cgu.9.rcgu.o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7.1kfug2n7ufj0iis9.rcgu.o" "-L" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/deps" "-L" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-14131fec8d68ac91.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libpanic_unwind-b9f6e3876ed2586c.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libobject-86fcbf6a3440cba5.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libmemchr-d18a5d6796083fb1.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libaddr2line-d6774f4e1f890943.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libgimli-d280ea049e216073.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_demangle-adf188cef5835aec.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd_detect-3319673a080f2054.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libhashbrown-fdeb0068d017c92e.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_alloc-d3d760f168f99f16.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libunwind-bbc1ff69954ec7aa.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcfg_if-eb937e4ebb9dfc13.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/liblibc-b7ebdbddd4f4f732.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/liballoc-a4fd6bd0981bd1bd.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_core-a6ba5abd095110d9.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcore-081494498d0f8be5.rlib" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-4b0e4c844ac47183.rlib" "-lSystem" "-lresolv" "-lc" "-lm" "-liconv" "-L" "/Users/andrepopovitch/.rustup/toolchains/1.60.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/Users/andrepopovitch/dev/work/dfinity/ic/rs/target/debug/build/futures-channel-1ea32a5acb5d93e7/build_script_build-1ea32a5acb5d93e7" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: ld: library not found for -liconv
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

## The solution

This is probably an incomplete or suboptimal solution, but just adding `-L=${libiconv-static.out}/lib` to the `cc` invocation that failed fixed the problem. So I added it to `RUSTFLAGS` in `ic.nix` so that cargo would include it when calling `cc`, and now the build works!