### PR TITLE
Add rust_src_path environment variable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ let
       rust-bindgen = super.rust-bindgen.overrideAttrs (_: { doCheck = false; });
       rust-stable = super.rust-bin.stable.latest.default.override {
         targets = [ "wasm32-unknown-unknown" ];
+        extensions = [ "rust-src" ];
       };
       rustPlatform = super.makeRustPlatform {
         rustc = self.rust-stable;

--- a/ic.nix
+++ b/ic.nix
@@ -106,6 +106,7 @@ let
         "-Lall=${libiconv-static.out}/lib"
         "-lstatic=iconv"
       ];
+      RUST_SRC_PATH = "${rust-stable}/lib/rustlib/src/rust/library";
 
       buildPhase = ''
         cargo build --profile ${profile} --target ${hostTriple} $cargoBuildFlags


### PR DESCRIPTION
# Problem

Rust-analyzer looks for the `RUST_SRC_PATH` environment variable, which is not being set. If you have rustup installed globally, it'll probably be using that `RUST_SRC_PATH`, which is bad because it might not be the same as the one installed by nix-ic. 

# Solution

Add the environment variable to `ic.nix`.

# Depends

Depends on #20

# Notes

I suspect that this is not the right way to do this, because we should ideally be setting `RUST_SRC_PATH` for every project, not just `ic.nix`. But I wasn't sure how to accomplish that and I didn't want to just copy paste it into every `.nix` file.