### PR TITLE
Add vscode and direnv instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ For aarch64 (Apple M1) architecture, you have a couple choices:
 
 Before you compile from source, you may also want to setup the binary cache (courtesy of [cachix]) by `nix-shell -p cachix --run 'cachix use ninegua'` to avoid unnecessary compilation.
 
+**VSCode/direnv**
+
+Assuming you're developing on `ic`.
+
+1. Make sure you have [`direnv`](https://direnv.net/) installed.
+1. Clone this repo next to `ic`.
+2. Under `ic/rs`: run `echo "use nix ../../ic-nix/default.nix -A ic.shell" > .envrc`. 
+3. In the same directory, run `direnv allow .`
+
+If using VSCode, you should also install the [direnv vscode extension](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv), to make sure that rust-analyzer will be using the same versions of Rust as your shell.
+
 **WARNING**
 
 Releases are built against the latest main branches of each project on a weekly update schedule. They may not always work. Please understand the risks before proceed.

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@ let
       rust-bindgen = super.rust-bindgen.overrideAttrs (_: { doCheck = false; });
       rust-stable = super.rust-bin.stable.latest.default.override {
         targets = [ "wasm32-unknown-unknown" ];
+        extensions = [ "rust-src" ];
       };
       rustPlatform = super.makeRustPlatform {
         rustc = self.rust-stable;

--- a/ic.nix
+++ b/ic.nix
@@ -106,6 +106,7 @@ let
         "-Lall=${libiconv-static.out}/lib"
         "-lstatic=iconv"
       ];
+      RUST_SRC_PATH = "${rust-stable}/lib/rustlib/src/rust/library";
 
       buildPhase = ''
         cargo build --profile ${profile} --target ${hostTriple} $cargoBuildFlags


### PR DESCRIPTION
Setting up direnv and vscode is non-obvious, I figured it out and figured it should be documented somewhere. I only tested it for `ic` (since that's what I work on) but the instructions should work for other platforms, especially once the modification in #21 is applied to all the other projects.

# Depends

!20, !21