### PR TITLE
Upgrade OS support to 22.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '22.05' ]
+        channel: [ '22.11', '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -21,6 +21,8 @@ jobs:
             prefix: nixpkgs
           - channel: '22.05'
             channel-darwin: '22.05-darwin'
+          - channel: '22.11'
+            channel-darwin: '22.11-darwin'
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -49,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [ 'motoko', 'ic-no-shell', 'sdk', 'utils' ]
-        channel: [ '22.05' ]
+        channel: [ '22.11', '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -60,6 +62,8 @@ jobs:
             name: darwin
           - channel: '22.05'
             channel-darwin: '22.05-darwin'
+          - channel: '22.11'
+            channel-darwin: '22.11-darwin'
 
     steps:
     - name: Maximize build space

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Supported platforms:
 Supported nixpkgs:
 
 - [x] 22.05
-- [ ] 22.11 (WIP)
+- [x] 22.11
 - [ ] unstable
 
 Feature:


### PR DESCRIPTION
Drop the support of NixOS 21.11, and add support for 22.11.

Things preventing this from being merged:

- [ ] 22.11-darwin has a compilation error for python3
- [ ] replica build already renamed canister-http to https-outcall, but dfx has yet to support it