### PR TITLE
Add binary ic-state-machine-tests

### DIFF
--- a/dfx-env.nix
+++ b/dfx-env.nix
@@ -51,12 +51,12 @@ let
   in makeDrv { inherit (release) binaries canisters; };
 
   dfxBins = [
+    "canister_sandbox"
     "dfx"
-    "replica"
     "ic-starter"
     "ic-btc-adapter"
     "ic-https-outcalls-adapter"
-    "canister_sandbox"
+    "ic-state-machine-tests"
     "ic-ref"
     "ic-starter"
     "icx-proxy"

--- a/ic.nix
+++ b/ic.nix
@@ -21,6 +21,7 @@ let
     "ic-https-outcalls-adapter"
     "canister_sandbox"
     "sandbox_launcher"
+    "ic-state-machine-tests"
   ];
 
   wasms = [

--- a/release.nix
+++ b/release.nix
@@ -7,7 +7,7 @@ with import ./. { inherit pkgs; }; rec {
     installPhase = ''
       mkdir -p $out/bin $out/share
       cp ${moc}/bin/mo* $out/bin/
-      cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-https-outcalls-adapter,canister_sandbox,sandbox_launcher} $out/bin/
+      cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-https-outcalls-adapter,ic-state-machine-tests,canister_sandbox,sandbox_launcher} $out/bin/
       cp ${dfx}/bin/* $out/bin/
       cp ${icx-proxy}/bin/* $out/bin/
       cp ${idl2json}/bin/* $out/bin/


### PR DESCRIPTION
Solves #38 

Note that according to `state_machine_tests/Cargo.toml` from the ic repo, the binary is called `ic-state-machine-tests`. However, `BUILD.bazel` builds it under a different name called `ic-test-state-machine`. 