### PR TITLE
Drop support for NixOS 21.11

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - uses: cachix/install-nix-action@v17
       with:
-        nix_path: nixpkgs=channel:nixos-21.11
+        nix_path: nixpkgs=channel:nixos-22.05
 
     - name: Update sources.nix
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '22.11', '22.05' ]
+        channel: [ '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [ 'motoko', 'ic-no-shell', 'sdk', 'utils' ]
-        channel: [ '22.11', '22.05' ]
+        channel: [ '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '21.11', '22.05' ]
+        channel: [ '22.11', '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
             prefix: nixos
           - os: macos-latest
             prefix: nixpkgs
-          - channel: '21.11'
-            channel-darwin: '21.11-darwin'
+          - channel: '22.11'
+            channel-darwin: '22.11-darwin'
           - channel: '22.05'
             channel-darwin: '22.05-darwin'
 
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [ 'motoko', 'ic-no-shell', 'sdk', 'utils' ]
-        channel: [ '21.11', '22.05' ]
+        channel: [ '22.11', '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -60,8 +60,8 @@ jobs:
           - os: macos-latest
             prefix: nixpkgs
             name: darwin
-          - channel: '21.11'
-            channel-darwin: '21.11-darwin'
+          - channel: '22.11'
+            channel-darwin: '22.11-darwin'
           - channel: '22.05'
             channel-darwin: '22.05-darwin'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
             prefix: nixos
           - os: macos-latest
             prefix: nixpkgs
-          - channel: '22.11'
-            channel-darwin: '22.11-darwin'
           - channel: '22.05'
             channel-darwin: '22.05-darwin'
 
@@ -60,8 +58,6 @@ jobs:
           - os: macos-latest
             prefix: nixpkgs
             name: darwin
-          - channel: '22.11'
-            channel-darwin: '22.11-darwin'
           - channel: '22.05'
             channel-darwin: '22.05-darwin'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [ '21.11' ]
+        channel: [ '22.05' ]
         os: [ ubuntu-latest, macos-latest ]
         include:
           - os: ubuntu-latest
@@ -20,8 +20,8 @@ jobs:
           - os: macos-latest
             name: darwin
             prefix: nixpkgs
-          - channel: '21.11'
-            channel-darwin: '21.11-darwin'
+          - channel: '22.05'
+            channel-darwin: '22.05-darwin'
 
     steps:
     - uses: actions/checkout@v2.3.4

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Supported platforms:
 Supported nixpkgs:
 
 - [x] 22.05
-- [x] 22.11
+- [ ] 22.11 (WIP)
 - [ ] unstable
 
 Feature:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Supported platforms:
 
 Supported nixpkgs:
 
-- [x] 21.11
 - [x] 22.05
+- [x] 22.11
 - [ ] unstable
 
 Feature:

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ let
         rustc = self.rust-stable;
         cargo = self.rust-stable;
       };
-      rust-nightly = self.rust-bin.nightly."2022-05-16".default.override {
+      rust-nightly = self.rust-bin.nightly."2022-12-15".default.override {
         targets = [ "wasm32-unknown-emscripten" "wasm32-wasi" ];
         extensions = [ "rust-src" ];
       };

--- a/dfx-env.nix
+++ b/dfx-env.nix
@@ -73,12 +73,18 @@ let
         }_PATH";
       value = "${drv}/bin/${name}";
     }) list);
+  # Workaround for the name change that is yet to be incorporated into dfx
+  modify = paths:
+    (paths // {
+      "DFX_IC_CANISTER_HTTP_ADAPTER_PATH" =
+        paths."DFX_IC_HTTPS_OUTCALLS_ADAPTER_PATH";
+    });
   shellFor = drv:
     mkShell ({
       nobuildPhase = "touch $out";
       nativeBuildInputs = [ drv ];
       DFX_CACHE_ROOT = "${drv}/share/dfx";
-    } // dfxPaths drv dfxBins);
+    } // modify (dfxPaths drv dfxBins));
   warn = mkShell ({
     phases = [ "WARNING" ];
     WARNING = ''

--- a/dfx-env.nix
+++ b/dfx-env.nix
@@ -55,7 +55,7 @@ let
     "replica"
     "ic-starter"
     "ic-btc-adapter"
-    "ic-canister-http-adapter"
+    "ic-https-outcalls-adapter"
     "canister_sandbox"
     "ic-ref"
     "ic-starter"

--- a/ic.nix
+++ b/ic.nix
@@ -18,7 +18,7 @@ let
     "ic-consensus-pool-util"
     "state-tool"
     "ic-btc-adapter"
-    "ic-canister-http-adapter"
+    "ic-https-outcalls-adapter"
     "canister_sandbox"
     "sandbox_launcher"
   ];

--- a/ic.nix
+++ b/ic.nix
@@ -91,7 +91,7 @@ let
       else
         [ libunwind-static ]);
       cargoSha256 =
-        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+        "sha256-q5H/mXLiwYFw/48oACEzDH9xNsnfs0gc7TIEbDU/Vjk="; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/ic.nix
+++ b/ic.nix
@@ -91,7 +91,7 @@ let
       else
         [ libunwind-static ]);
       cargoSha256 =
-        "sha256-q5H/mXLiwYFw/48oACEzDH9xNsnfs0gc7TIEbDU/Vjk="; # cargoSha256
+        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/ic.nix
+++ b/ic.nix
@@ -75,7 +75,7 @@ let
         chmod -R u+w -- "$sourceRoot"
         runHook postUnpack
       '';
-      sourceRoot = "${name}/rs";
+      sourceRoot = "${name}";
       nativeBuildInputs =
         [ moc cmake llvmPackages.clang pkg-config python3 rustfmt protobuf ];
       buildInputs = [
@@ -91,7 +91,7 @@ let
       else
         [ libunwind-static ]);
       cargoSha256 =
-        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+        "sha256-MPOXuoe0/mWsbX2e5Bpw9yeh9gmJQvXbI+tKc0F437I="; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/ic.nix
+++ b/ic.nix
@@ -91,7 +91,7 @@ let
       else
         [ libunwind-static ]);
       cargoSha256 =
-        "sha256-QRWX+rsjeVP+OUBMGr7bna+5sdJ8LbEZIKw2Fuawegc="; # cargoSha256
+        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/motoko.nix
+++ b/motoko.nix
@@ -159,7 +159,7 @@ in rec {
       name = "cargo-vendor-tools";
       src = "${sources.motoko}/rts/${name}/";
       cargoSha256 =
-        "sha256-gzLk4kNBSbd8ujJ/7mNs/vwCu76ASqtyoVU84PdaJCw="; # cargoSha256
+        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
     };
 
     # Path to vendor-rust-std-deps, provided by cargo-vendor-tools

--- a/motoko.nix
+++ b/motoko.nix
@@ -159,7 +159,7 @@ in rec {
       name = "cargo-vendor-tools";
       src = "${sources.motoko}/rts/${name}/";
       cargoSha256 =
-        "sha256-CrtZQTac95MEbk3uapviLgcQjEt5VUnTOG9fiJXIAU8="; # cargoSha256
+        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
     };
 
     # Path to vendor-rust-std-deps, provided by cargo-vendor-tools

--- a/motoko.nix
+++ b/motoko.nix
@@ -7,7 +7,7 @@ let
   ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_12;
   obelisk = import "${sources.motoko}/nix/ocaml-obelisk.nix" {
     inherit (pkgs) lib fetchFromGitHub;
-    inherit (ocamlPackages) ocaml dune_2;
+    inherit (ocamlPackages) ocaml dune_3;
     inherit ocamlPackages;
     inherit (pkgs.stdenv) mkDerivation;
   };
@@ -67,7 +67,7 @@ let
     export CLANG="${pkgs.clang_13}/bin/clang"
   '';
   commonBuildInputs = with pkgs; [
-    ocamlPackages.dune_2
+    ocamlPackages.dune_3
     ocamlPackages.ocaml
     ocamlPackages.atdgen
     ocamlPackages.checkseum
@@ -159,14 +159,14 @@ in rec {
       name = "cargo-vendor-tools";
       src = "${sources.motoko}/rts/${name}/";
       cargoSha256 =
-        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+        "sha256-gzLk4kNBSbd8ujJ/7mNs/vwCu76ASqtyoVU84PdaJCw="; # cargoSha256
     };
 
     # Path to vendor-rust-std-deps, provided by cargo-vendor-tools
     vendorRustStdDeps = "${cargoVendorTools}/bin/vendor-rust-std-deps";
 
     # SHA256 of Rust std deps
-    rustStdDepsHash = "sha256-vKsuuJFfmsQp4g3rmDoRaRrTBSiBZg78colfqY1qWl8=";
+    rustStdDepsHash = "sha256-sRerHg2LoEiH/dBR/lY/e80rZQv+SFQTOCX9CD+NV+s=";
 
     # Vendor directory for Rust std deps
     rustStdDeps = pkgs.stdenvNoCC.mkDerivation {
@@ -191,7 +191,7 @@ in rec {
       name = "motoko-rts-deps";
       src = "${sources.motoko}/rts";
       sourceRoot = "rts/motoko-rts-tests";
-      sha256 = "sha256-VKNXQ7uT5njmZ4RlF1Lebyy7hPSw+KRjG8ntCXfw/Y4";
+      sha256 = "sha256-jCk92mPwXd8H8zEH4OMdcEwFM8IiYdlhYdYr+WzDW5E=";
       copyLockfile = true;
     };
 

--- a/motoko.nix
+++ b/motoko.nix
@@ -159,7 +159,7 @@ in rec {
       name = "cargo-vendor-tools";
       src = "${sources.motoko}/rts/${name}/";
       cargoSha256 =
-        "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+        "sha256-gzLk4kNBSbd8ujJ/7mNs/vwCu76ASqtyoVU84PdaJCw="; # cargoSha256
     };
 
     # Path to vendor-rust-std-deps, provided by cargo-vendor-tools

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,8 +1,8 @@
 { fetchgit }: {
   ic = fetchgit {
     url = "https://github.com/dfinity/ic"; # master
-    rev = "cec9976e224701d89082796dfcfb63727c80e167";
-    sha256 = "05lnk5djnf1435qlij8asxam9bjzxvn2rw3v4f4a25mfakiq09ni";
+    rev = "8cec935302f157bc20ff9583fd8bc96b5d48b71e";
+    sha256 = "0my8mw0i9xy9r4f5ix52i972pn8rm4cyvs3s7ahz9fzlkcm1338m";
   };
   icx-proxy = fetchgit {
     url = "https://github.com/dfinity/icx-proxy"; # master
@@ -16,23 +16,23 @@
   };
   motoko = fetchgit {
     url = "https://github.com/dfinity/motoko"; # master
-    rev = "b8b34d7831270c02dce8e11aa4146d6867d7942c";
-    sha256 = "0ynw4yifgpw7pylsrw0dj1dfbaj37nd403i6r08vjkj6apj4cmb4";
+    rev = "dcfa0a635ce27b389f16df6ef42aa043662f508a";
+    sha256 = "1yrqg5j2wq9v9v8jbd3337yk6xdwlvmdpfl9c400szsi93wqxj3a";
   };
   motoko-base = fetchgit {
     url = "https://github.com/dfinity/motoko-base"; # next-moc
-    rev = "5c9145e79bf471fb662b9b4028937783e97e23d1";
-    sha256 = "0vxf5w7dyzhbf6qcqs6y9xwa6kvw39xk5h9mdn573zb5fa1ip5ny";
+    rev = "8c70bf452e16a9e81d95b764b636e2bee3fd0b39";
+    sha256 = "101nbb5ws43rlkh96fvdcjzdkhwpl33fsl4bxfnfq10835vyn3kz";
   };
   musl-wasi = fetchgit {
     url = "https://github.com/WebAssembly/wasi-libc"; # main
-    rev = "082a15c5a92f044a2873d3a099dab863c037c7a8";
-    sha256 = "0wr4arq38wqn4qd5pgdvz12w899wczi0sz54i1jb68h91vjkdnm4";
+    rev = "8daaba387ce70a6088afe3916e9e16ed1c2bc630";
+    sha256 = "0818aqsn6clm8nc0adbzah67dkhzjc8z20qfgiwq76690jgnp5d4";
   };
   sdk = fetchgit {
     url = "https://github.com/dfinity/sdk"; # master
-    rev = "634680d7f0b09a36a335ae92c9e8ecec19921c7d";
-    sha256 = "1n634bjdzh6v1ripzk2a0frb4r3vmajs0nmkijfi3iy3rdplbi2p";
+    rev = "bc2283ede24820dfeada4e69b9f3672e1ff53990";
+    sha256 = "1kh86fflb6pszx0bivx7k0mlix09ffwl81zhwmzy4ci60w0vcpkg";
   };
   lmdb = fetchgit {
     url = "https://git.openldap.org/openldap/openldap.git"; # mdb.master
@@ -41,18 +41,18 @@
   };
   vessel = fetchgit {
     url = "https://github.com/dfinity/vessel"; # main
-    rev = "3b38f3f75f3334d558a4fc9ed0290fee61f67224";
-    sha256 = "1zb2zbp8kdllg84zr5376ah22cry2d3v3gjwhxh3x1nhmbxf216k";
+    rev = "e0688426d630e378eb22b1a6a0fa130a8be95685";
+    sha256 = "0flh8nb5hc0sdfp7kkzqxbqdjclkdczb2qv6d09zbs6y8crp9x1j";
   };
   ic-repl = fetchgit {
     url = "https://github.com/chenyan2002/ic-repl"; # master
-    rev = "3b63aaca78d2910e5481f1d116f2a228f7441194";
-    sha256 = "1lcxzy44s0dqiwzd9ib0vs76g157ndacl9wazrjj5wlw3gfn3yj9";
+    rev = "9adb8a183d2ef6d4425c5c36b04edd36bab76446";
+    sha256 = "1rbif5v10ri9cvdy6dlhyf3nbbb1dhf8szxfczzmdb5dc4kgjn1g";
   };
   candid = fetchgit {
     url = "https://github.com/dfinity/candid"; # master
-    rev = "b15c305046b675fca083477f5fe5ac8dee96315a";
-    sha256 = "00v8jvskaml6rnyii1r62jm84arbxqrhdpg1nks6nswflhzh7xmc";
+    rev = "42ffed660ded37585c4b9f97e3ce90919e24c518";
+    sha256 = "1hpvkk8f98vzz7fzbd6q8xw9l89ybb87yxmw421skkdgpx6sakky";
   };
 
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,8 +1,8 @@
 { fetchgit }: {
   ic = fetchgit {
     url = "https://github.com/dfinity/ic"; # master
-    rev = "8cec935302f157bc20ff9583fd8bc96b5d48b71e";
-    sha256 = "0my8mw0i9xy9r4f5ix52i972pn8rm4cyvs3s7ahz9fzlkcm1338m";
+    rev = "2e27bd630dd32d582b3e8aa941182b212e7f60f0";
+    sha256 = "0lc5bja552zzz6wz95y698bln6g0a98pww0zfhdhydyh9mliqqa4";
   };
   icx-proxy = fetchgit {
     url = "https://github.com/dfinity/icx-proxy"; # master
@@ -16,23 +16,23 @@
   };
   motoko = fetchgit {
     url = "https://github.com/dfinity/motoko"; # master
-    rev = "dcfa0a635ce27b389f16df6ef42aa043662f508a";
-    sha256 = "1yrqg5j2wq9v9v8jbd3337yk6xdwlvmdpfl9c400szsi93wqxj3a";
+    rev = "0bea8a5e225b615693eb9929e2b198bf7a937205";
+    sha256 = "0zqidw58k3g1x8p0sjq4scn452dqfhr0bgj35msbc3fafmsyfldz";
   };
   motoko-base = fetchgit {
     url = "https://github.com/dfinity/motoko-base"; # next-moc
-    rev = "8c70bf452e16a9e81d95b764b636e2bee3fd0b39";
-    sha256 = "101nbb5ws43rlkh96fvdcjzdkhwpl33fsl4bxfnfq10835vyn3kz";
+    rev = "98c5717b283a8ec233907c3a3e92c79e3bbab1b3";
+    sha256 = "1hji6j89p2yk975yxpb0p4xzx4vxa6qa14f0vm1ls0f5jq8ch99g";
   };
   musl-wasi = fetchgit {
     url = "https://github.com/WebAssembly/wasi-libc"; # main
-    rev = "8daaba387ce70a6088afe3916e9e16ed1c2bc630";
-    sha256 = "0818aqsn6clm8nc0adbzah67dkhzjc8z20qfgiwq76690jgnp5d4";
+    rev = "f2a35a454e8472b63831885daacc7f5fadd46747";
+    sha256 = "1k7hkx9q9d93xcdmpnp519znvfffh10xk1y853pdjxnlmxndkw9j";
   };
   sdk = fetchgit {
     url = "https://github.com/dfinity/sdk"; # master
-    rev = "bc2283ede24820dfeada4e69b9f3672e1ff53990";
-    sha256 = "1kh86fflb6pszx0bivx7k0mlix09ffwl81zhwmzy4ci60w0vcpkg";
+    rev = "a19bb11a066e6b324d9750d346e8b56b32ae50fa";
+    sha256 = "0adsv7nlgd5w4qn5rzs94gg7g7hy15lfnlz9nq9n19c9h5b8gs09";
   };
   lmdb = fetchgit {
     url = "https://git.openldap.org/openldap/openldap.git"; # mdb.master
@@ -41,13 +41,13 @@
   };
   vessel = fetchgit {
     url = "https://github.com/dfinity/vessel"; # main
-    rev = "e0688426d630e378eb22b1a6a0fa130a8be95685";
-    sha256 = "0flh8nb5hc0sdfp7kkzqxbqdjclkdczb2qv6d09zbs6y8crp9x1j";
+    rev = "99661e40c4c47110129176ee9ecc61a50f1f60db";
+    sha256 = "0azbr1gz6xlk9dwr5zc451krnvb5p3g2fl7iyjh0zhpylb5v3d4y";
   };
   ic-repl = fetchgit {
     url = "https://github.com/chenyan2002/ic-repl"; # master
-    rev = "9adb8a183d2ef6d4425c5c36b04edd36bab76446";
-    sha256 = "1rbif5v10ri9cvdy6dlhyf3nbbb1dhf8szxfczzmdb5dc4kgjn1g";
+    rev = "58374a36f80d25b1aeefb2e0e7b962cf20fcd755";
+    sha256 = "1100m8s6w7gl2wh255n0d1d8c8jkbplkwzrcxxrr418v3gkd189w";
   };
   candid = fetchgit {
     url = "https://github.com/dfinity/candid"; # master

--- a/release.nix
+++ b/release.nix
@@ -7,7 +7,7 @@ with import ./. { inherit pkgs; }; rec {
     installPhase = ''
       mkdir -p $out/bin $out/share
       cp ${moc}/bin/mo* $out/bin/
-      cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-canister-http-adapter,canister_sandbox,sandbox_launcher} $out/bin/
+      cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-https-outcalls-adapter,canister_sandbox,sandbox_launcher} $out/bin/
       cp ${dfx}/bin/* $out/bin/
       cp ${icx-proxy}/bin/* $out/bin/
       cp ${vessel}/bin/* $out/bin/

--- a/sdk.nix
+++ b/sdk.nix
@@ -9,7 +9,7 @@ let
     name = "dfx";
     inherit src;
     cargoSha256 =
-      "sha256-2nR7hzT0cJ2RRhp2ibPXbWdzRKfdYEs3dmMnSoc/VOE="; # cargoSha256
+      "0000000000000000000000000000000000000000000000000000"; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ perl pkg-config cmake binaryen python3 ];
     preConfigure = ''

--- a/sdk.nix
+++ b/sdk.nix
@@ -9,7 +9,7 @@ let
     name = "dfx";
     inherit src;
     cargoSha256 =
-      "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+      "sha256-PAsdHsgNdsnF2yf71bpFCYFWLtl+YAt0KRzeJf6ZerQ="; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ perl pkg-config cmake binaryen python3 ];
     preConfigure = ''

--- a/sdk.nix
+++ b/sdk.nix
@@ -9,7 +9,7 @@ let
     name = "dfx";
     inherit src;
     cargoSha256 =
-      "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+      "sha256-fE2CQX7yrzX2s9O1WjthJXu7NTxPDBabSVQOIPwAeko="; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ perl pkg-config cmake binaryen python3 ];
     preConfigure = ''

--- a/sdk.nix
+++ b/sdk.nix
@@ -9,7 +9,7 @@ let
     name = "dfx";
     inherit src;
     cargoSha256 =
-      "sha256-fE2CQX7yrzX2s9O1WjthJXu7NTxPDBabSVQOIPwAeko="; # cargoSha256
+      "0000000000000000000000000000000000000000000000000000"; # cargoSha256
     inherit buildInputs;
     nativeBuildInputs = [ perl pkg-config cmake binaryen python3 ];
     preConfigure = ''

--- a/utils.nix
+++ b/utils.nix
@@ -20,13 +20,13 @@ let
   mkDrv = mkDrv_ [ ];
 in rec {
   icx-proxy = mkDrv "icx-proxy"
-    "sha256-Zv9wBf32sv/bQUo4do+xejil5KQebtS/3rGbiRdomnQ="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   vessel = mkDrv "vessel"
-    "sha256-OQp+lq21gz7QRyWmokxKqBRaXGkuvMtlgi1Z+vI7VbQ="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   ic-repl = mkDrv "ic-repl"
-    "sha256-Yxb5NhuB+ieOfTAhsijKsjl2ZMzwhqDbiY3RHNmzFZQ="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   candid = mkDrv "candid"
-    "sha256-7bBrLVs/GSlzNnJktkbtMrsnunPy7PqKnkPSrVyjVxY="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
 
   shell = icx-proxy;
 }

--- a/utils.nix
+++ b/utils.nix
@@ -20,13 +20,13 @@ let
   mkDrv = mkDrv_ [ ];
 in rec {
   icx-proxy = mkDrv "icx-proxy"
-    "sha256-Zv9wBf32sv/bQUo4do+xejil5KQebtS/3rGbiRdomnQ="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   vessel = mkDrv "vessel"
-    "sha256-+gx9kKgS4M+usVWK/sK34/7XFob5Vn4K6Ha5rBJ9Dgs="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   ic-repl = mkDrv "ic-repl"
-    "sha256-mmHgtcExeiQ1J9TzFqDsLyhnbnE7+LKGPAYg1bbXAjM="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
   candid = mkDrv "candid"
-    "sha256-3DtEkpyeJi2VcpJOXnZCPvwrQH/C9Tnr4xjZ/X4PQsQ="; # cargoSha256
+    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
 
   shell = icx-proxy;
 }

--- a/utils.nix
+++ b/utils.nix
@@ -20,13 +20,13 @@ let
   mkDrv = mkDrv_ [ ];
 in rec {
   icx-proxy = mkDrv "icx-proxy"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-Zv9wBf32sv/bQUo4do+xejil5KQebtS/3rGbiRdomnQ="; # cargoSha256
   vessel = mkDrv "vessel"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-+gx9kKgS4M+usVWK/sK34/7XFob5Vn4K6Ha5rBJ9Dgs="; # cargoSha256
   ic-repl = mkDrv "ic-repl"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-x6xNF5Pg2Tu0uYX0o0Ywoh87k434Bk56zHvrfVCrTWU="; # cargoSha256
   candid = mkDrv "candid"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-3DtEkpyeJi2VcpJOXnZCPvwrQH/C9Tnr4xjZ/X4PQsQ="; # cargoSha256
 
   shell = icx-proxy;
 }

--- a/utils.nix
+++ b/utils.nix
@@ -20,13 +20,13 @@ let
   mkDrv = mkDrv_ [ ];
 in rec {
   icx-proxy = mkDrv "icx-proxy"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-Zv9wBf32sv/bQUo4do+xejil5KQebtS/3rGbiRdomnQ="; # cargoSha256
   vessel = mkDrv "vessel"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-+gx9kKgS4M+usVWK/sK34/7XFob5Vn4K6Ha5rBJ9Dgs="; # cargoSha256
   ic-repl = mkDrv "ic-repl"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-mmHgtcExeiQ1J9TzFqDsLyhnbnE7+LKGPAYg1bbXAjM="; # cargoSha256
   candid = mkDrv "candid"
-    "0000000000000000000000000000000000000000000000000000"; # cargoSha256
+    "sha256-3DtEkpyeJi2VcpJOXnZCPvwrQH/C9Tnr4xjZ/X4PQsQ="; # cargoSha256
 
   shell = icx-proxy;
 }


### PR DESCRIPTION
- NixOS 21.11 is no longer maintained.
- Workaround for the name clash between replica and dfx in the names of https_outcall vs. canister_http