### PR TITLE
Build sns command

### DIFF
--- a/ic.nix
+++ b/ic.nix
@@ -22,6 +22,7 @@ let
     "canister_sandbox"
     "sandbox_launcher"
     "ic-state-machine-tests"
+    "sns"
   ];
 
   wasms = [

--- a/release.nix
+++ b/release.nix
@@ -8,6 +8,7 @@ with import ./. { inherit pkgs; }; rec {
       mkdir -p $out/bin $out/share
       cp ${moc}/bin/mo* $out/bin/
       cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-https-outcalls-adapter,ic-state-machine-tests,canister_sandbox,sandbox_launcher} $out/bin/
+      cp ${ic.binaries}/bin/sns $out/bin/sns-cli
       cp ${dfx}/bin/* $out/bin/
       cp ${icx-proxy}/bin/* $out/bin/
       cp ${idl2json}/bin/* $out/bin/


### PR DESCRIPTION
The `sns-cli` command is actually called `sns` according to Cargo.toml.