### PR TITLE
Use the latest ic release version

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -17,8 +17,8 @@ jobs:
 
     - name: Update sources.nix
       run: |
-        nix-env -f '<nixpkgs>' -iA update-nix-fetchgit
-        update-nix-fetchgit ./nix/sources.nix
+        nix-env -f '<nixpkgs>' -iA update-nix-fetchgit jq gnumake
+        make update-sources
         sed -i 's/"\([^")]*\)"; *# cargoSha256/"0000000000000000000000000000000000000000000000000000"; # cargoSha256/' *.nix
 
     - name: Create Pull Request

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,16 @@ ic-binaries-$(VERSION)-$(SYSTEM).tar.gz:
 ic-canisters-$(VERSION)-wasm32.tar.gz:
 	tar -zcv -C $$(nix-build --pure release.nix --no-out-link -A canisters) --transform "s,^.,ic-canisters-$(VERSION)," -f $@ .
 
-.PHONY: binaries canisters default all
+subnet-replica-versions:
+	curl https://ic-api.internetcomputer.org/api/v3/subnet-replica-versions?limit=1 -O
 
+replica-rev: subnet-replica-versions
+	cat $< | jq -r '.data[0].replica_version_id' > $@
+
+update-sources-ic: nix/sources.nix replica-rev
+	sed -i "0,/pin/{s/\"[^\"]*\"; # pin/\"$$(cat replica-rev)\"; # pin/}" $<
+
+update-sources: nix/sources.nix update-sources-ic
+	update-nix-fetchgit $<
+
+.PHONY: update-sources binaries canisters default all


### PR DESCRIPTION
All IC replica releases are available through https://ic-api.internetcomputer.org/api/v3/subnet-replica-versions
Only the released versions have binary downloads available at https://download.dfinity.systems/

We should always look up and use the latest released revision.