### PR TITLE
Fix dfx nns install

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -17,8 +17,8 @@ jobs:
 
     - name: Update sources.nix
       run: |
-        nix-env -f '<nixpkgs>' -iA update-nix-fetchgit
-        update-nix-fetchgit ./nix/sources.nix
+        nix-env -f '<nixpkgs>' -iA update-nix-fetchgit jq gnumake
+        make update-sources
         sed -i 's/"\([^")]*\)"; *# cargoSha256/"0000000000000000000000000000000000000000000000000000"; # cargoSha256/' *.nix
 
     - name: Create Pull Request

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,16 @@ ic-binaries-$(VERSION)-$(SYSTEM).tar.gz:
 ic-canisters-$(VERSION)-wasm32.tar.gz:
 	tar -zcv -C $$(nix-build --pure release.nix --no-out-link -A canisters) --transform "s,^.,ic-canisters-$(VERSION)," -f $@ .
 
-.PHONY: binaries canisters default all
+subnet-replica-versions:
+	curl https://ic-api.internetcomputer.org/api/v3/subnet-replica-versions?limit=1 -O
 
+replica-rev: subnet-replica-versions
+	cat $< | jq -r '.data[0].replica_version_id' > $@
+
+update-sources-ic: nix/sources.nix replica-rev
+	sed -i "0,/pin/{s/\"[^\"]*\"; # pin/\"$$(cat replica-rev)\"; # pin/}" $<
+
+update-sources: nix/sources.nix update-sources-ic
+	update-nix-fetchgit $<
+
+.PHONY: update-sources binaries canisters default all

--- a/dfx-env.nix
+++ b/dfx-env.nix
@@ -28,7 +28,7 @@ let
       installPhase = ''
         mkdir -p $out/bin $out/share
         cp -r ${binaries}/bin/* $out/bin
-        cp -r ${canisters}/share/* $out/share
+        cp -r ${canisters}/share/{dfx-canisters,ic-canisters} $out/share
         ls -R $out
         chmod 755 $out/bin/*
         echo $phases
@@ -36,7 +36,8 @@ let
       createCachePhase = ''
         dfx_version=$($out/bin/dfx --version|cut -d' ' -f2)
         cache=$out/share/dfx/.cache/dfinity/versions/$dfx_version/
-        mkdir -p $cache/base
+        mkdir -p $cache/{base,wasms}
+        cp -r ${canisters}/share/wasms $cache/
         cp -r ${sources.motoko-base}/src/* $cache/base/
       '';
       /* cd $cache
@@ -53,9 +54,11 @@ let
   dfxBins = [
     "canister_sandbox"
     "dfx"
+    "ic-admin"
     "ic-starter"
     "ic-btc-adapter"
     "ic-https-outcalls-adapter"
+    "ic-nns-init"
     "ic-state-machine-tests"
     "ic-ref"
     "ic-starter"

--- a/ic.nix
+++ b/ic.nix
@@ -21,6 +21,7 @@ let
     "ic-https-outcalls-adapter"
     "canister_sandbox"
     "sandbox_launcher"
+    "ic-nns-init"
     "ic-state-machine-tests"
     "sns"
   ];
@@ -171,5 +172,5 @@ let
   };
 in {
   inherit binaries wasm-binaries canisters;
-  shell = mkBinaries { customLinker = false; };
+  shell = mkBinaries { customLinker = true; };
 }

--- a/ic.nix
+++ b/ic.nix
@@ -94,7 +94,7 @@ let
       else
         [ libunwind-static ]);
       cargoSha256 =
-        "sha256-mu7ey2r7Z0RnSjzgPpL77p6h5yvil34VJA6Pp9SOv18="; # cargoSha256
+        "sha256-jux/6QzEE56o/8jxWwaF1N5UOE9wZgH6eiuZR6M+qis="; # cargoSha256
       doCheck = false;
 
       ROCKSDB_LIB_DIR = "${rocksdb}/lib";

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,8 +1,8 @@
 { fetchgit }: {
   ic = fetchgit {
     url = "https://github.com/dfinity/ic"; # master
-    rev = "62bf2e969433a5a221d684b339187d8f752576d0";
-    sha256 = "16bb9pbylwa7qnbky0jfnp3gx11mi0csvpl129863kz9ra1zrpah";
+    rev = "2694487bb5594f68b43e1dc795142a8e48b45715"; # pin
+    sha256 = "1fkdh5mjycqx4w7kyrhiy5198n7arpgc00ka0ach2xwc0x9mdxaa";
   };
   icx-proxy = fetchgit {
     url = "https://github.com/dfinity/icx-proxy"; # master

--- a/release.nix
+++ b/release.nix
@@ -2,8 +2,7 @@
 with import ./. { inherit pkgs; };
 let
   sources = import ./nix/sources.nix { inherit (pkgs) fetchgit; };
-  ic_commit = builtins.unsafeDiscardStringContext
-    (pkgs.lib.strings.fileContents "${sdk.dfx}/share/replica-rev");
+  ic_commit = sources.ic.rev;
   wasm_names = [
     "registry-canister.wasm"
     "governance-canister_test.wasm"
@@ -11,7 +10,7 @@ let
     "ledger-canister_notify-method.wasm"
     "root-canister.wasm"
     "cycles-minting-canister.wasm"
-    "lifeline.wasm"
+    "lifeline_canister.wasm"
     "genesis-token-canister.wasm"
     "identity-canister.wasm"
     "nns-ui-canister.wasm"
@@ -69,8 +68,8 @@ in rec {
         cp $file $out/share/wasms/$target
         gunzip -k $out/share/wasms/$target || echo skip
       done
-      test -f $out/share/wasms/lifeline.wasm && cp $out/share/wasms/lifeline.wasm $out/share/wasms/lifeline_canister.wasm
-      test -f $out/share/wasms/lifeline.wasm.gz && cp $out/share/wasms/lifeline.wasm $out/share/wasms/lifeline_canister.wasm.gz
+      test -f $out/share/wasms/lifeline_canister.wasm && cp $out/share/wasms/lifeline_canister.wasm $out/share/wasms/lifeline.wasm
+      test -f $out/share/wasms/lifeline_canister.wasm.gz && cp $out/share/wasms/lifeline_canister.wasm.gz $out/share/wasms/lifeline.wasm.gz
       mv $out/share/wasms/nns-dapp_t2.wasm $out/share/wasms/nns-dapp_local.wasm
     '';
   };

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,37 @@
 { pkgs ? import <nixpkgs> { } }:
-with import ./. { inherit pkgs; }; rec {
+with import ./. { inherit pkgs; };
+let
+  sources = import ./nix/sources.nix { inherit (pkgs) fetchgit; };
+  ic_commit = builtins.unsafeDiscardStringContext
+    (pkgs.lib.strings.fileContents "${sdk.dfx}/share/replica-rev");
+  wasm_names = [
+    "registry-canister.wasm"
+    "governance-canister_test.wasm"
+    "governance-canister.wasm"
+    "ledger-canister_notify-method.wasm"
+    "root-canister.wasm"
+    "cycles-minting-canister.wasm"
+    "lifeline.wasm"
+    "genesis-token-canister.wasm"
+    "identity-canister.wasm"
+    "nns-ui-canister.wasm"
+    "sns-wasm-canister.wasm"
+    "ic-ckbtc-minter.wasm"
+    "sns-root-canister.wasm"
+    "sns-governance-canister.wasm"
+    "sns-swap-canister.wasm"
+    "ic-icrc1-ledger.wasm"
+    "ic-icrc1-archive.wasm"
+    "ic-icrc1-index.wasm"
+  ];
+  urls = map (wasm_name:
+    "https://download.dfinity.systems/ic/${ic_commit}/canisters/${wasm_name}.gz")
+    wasm_names;
+  downloads = map builtins.fetchurl (urls ++ [
+    "https://github.com/dfinity/internet-identity/releases/download/release-2022-07-11/internet_identity_dev.wasm"
+    "https://github.com/dfinity/nns-dapp/releases/download/tip/nns-dapp_t2.wasm"
+  ]);
+in rec {
   binaries = pkgs.stdenv.mkDerivation {
     name = "ic-nix-binaries";
     nativeBuildInputs = [ pkgs.patchelf ];
@@ -7,7 +39,7 @@ with import ./. { inherit pkgs; }; rec {
     installPhase = ''
       mkdir -p $out/bin $out/share
       cp ${moc}/bin/mo* $out/bin/
-      cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-https-outcalls-adapter,ic-state-machine-tests,canister_sandbox,sandbox_launcher,sns} $out/bin/
+      cp ${ic.binaries}/bin/{replica,ic-admin,ic-prep,ic-starter,ic-btc-adapter,ic-https-outcalls-adapter,ic-state-machine-tests,canister_sandbox,sandbox_launcher,ic-nns-init,sns} $out/bin/
       cp ${dfx}/bin/* $out/bin/
       cp ${icx-proxy}/bin/* $out/bin/
       cp ${idl2json}/bin/* $out/bin/
@@ -30,6 +62,16 @@ with import ./. { inherit pkgs; }; rec {
       mkdir -p $out/share
       cp -r ${ic.canisters}/share/ic-canisters $out/share/
       cp -r ${sdk.dfx}/share/dfx-canisters $out/share/
+      mkdir -p $out/share/wasms
+      for file in ${pkgs.lib.strings.concatStringsSep " " downloads}; do
+        echo Copying $file
+        target=`echo $file|sed -e 's/^[^-]*-//g'`
+        cp $file $out/share/wasms/$target
+        gunzip -k $out/share/wasms/$target || echo skip
+      done
+      test -f $out/share/wasms/lifeline.wasm && cp $out/share/wasms/lifeline.wasm $out/share/wasms/lifeline_canister.wasm
+      test -f $out/share/wasms/lifeline.wasm.gz && cp $out/share/wasms/lifeline.wasm $out/share/wasms/lifeline_canister.wasm.gz
+      mv $out/share/wasms/nns-dapp_t2.wasm $out/share/wasms/nns-dapp_local.wasm
     '';
   };
 }

--- a/sdk.nix
+++ b/sdk.nix
@@ -34,7 +34,6 @@ let
     postInstall = ''
       mkdir -p $out/share/dfx-canisters/
       cp $src/src/distributed/*.{wasm,did} $out/share/dfx-canisters/
-      grep replica-rev $src/src/dfx/assets/dfx-asset-sources.toml | sed -e "s/^[^']*'//" -e "s/'//" > $out/share/replica-rev
     '';
     RUSTFLAGS = [ "-Clinker=${linker}" "-Lnative=${libcxxabi}/lib" ]
       ++ lib.optionals stdenv.isDarwin [

--- a/sdk.nix
+++ b/sdk.nix
@@ -34,6 +34,7 @@ let
     postInstall = ''
       mkdir -p $out/share/dfx-canisters/
       cp $src/src/distributed/*.{wasm,did} $out/share/dfx-canisters/
+      grep replica-rev $src/src/dfx/assets/dfx-asset-sources.toml | sed -e "s/^[^']*'//" -e "s/'//" > $out/share/replica-rev
     '';
     RUSTFLAGS = [ "-Clinker=${linker}" "-Lnative=${libcxxabi}/lib" ]
       ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
To make `dfx nns install` work
- Fetch and install all required canister wasms from the same release revision used by ic binaries
- Make sure required binaries are setup through environment variable for dfx.