### PR TITLE
Separate canister compile

### DIFF
--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,8 +1,8 @@
 { fetchgit }: {
   ic = fetchgit {
     url = "https://github.com/dfinity/ic"; # master
-    rev = "9427aba69301dbaaa9b7eb48d809b01749b24d88"; # pin
-    sha256 = "1wvk4xrf3v8742ywg7jxyqnxd2k7k1pzf4dzakvplbj3y3dmlb01";
+    rev = "ad3da0d5fa0abad7d63fbaa6ca94642c2dd7f4ac"; # pin
+    sha256 = "sha256-IMIFyGD0Wo+yX7wNlWpAjdsrUi4zry5LOd5hm3JwQik=";
   };
   icx-proxy = fetchgit {
     url = "https://github.com/dfinity/icx-proxy"; # master


### PR DESCRIPTION
IC canister when compiled from the root directory of the monorepo would have unwanted imports due to `getrandom/js` feature being enabled in unrelated crates. To solve this problem it is best to compile them separately in their own sub-directories.