### PR TITLE
fix: Updated deprecated call to currently advised call

### DIFF
--- a/motoko.nix
+++ b/motoko.nix
@@ -179,7 +179,7 @@ in rec {
     };
 
     # Vendor tarball of the RTS
-    rtsDeps = pkgs.rustPlatform.fetchCargoTarball {
+    rtsDeps = pkgs.rustPlatform.fetchCargoVendor {
       name = "motoko-rts-deps";
       src = "${sources.motoko}/rts";
       sourceRoot = "rts/motoko-rts-tests";


### PR DESCRIPTION
When I try to run `nix develop`, the call fails for me. Looks like this call is deprecated
![image](https://github.com/user-attachments/assets/f208c300-c047-4dc5-badd-60a61d15ccaa)

## Steps to reproduce:
You can find a reproduction [here](https://github.com/dolr-ai/hot-or-not-backend-canister/blob/059ab2025f957c3e33d958727296666a845d50a8/flake.nix). Feel free to clone that commit and run
`nix develop --impure`
Change the nixpkgs input to point to the latest unstable