### PR TITLE
fix: fix hash mismatch

### DIFF
--- a/motoko.nix
+++ b/motoko.nix
@@ -151,7 +151,7 @@ in rec {
     cargoVendorTools = pkgs.rustPlatform.buildRustPackage rec {
       name = "cargo-vendor-tools";
       src = "${sources.motoko}/rts/${name}/";
-      cargoHash = "sha256-E6GTFvmZMjGsVlec7aH3QaizqIET6Dz8Csh0N1jeX+M=";
+      cargoHash = "sha256-5R4RbX+x+iUBUP5dW7PlN2Qlwn5qf0dRRmnlPh18RRA=";
     };
 
     # Path to vendor-rust-std-deps, provided by cargo-vendor-tools


### PR DESCRIPTION
Build fails owing to the hash mismatch as shown below
![image](https://github.com/user-attachments/assets/e9c35265-9ae4-426e-9c18-17052dbdaf84)

## Steps to reproduce:
You can find a reproduction [here](https://github.com/dolr-ai/hot-or-not-backend-canister/blob/059ab2025f957c3e33d958727296666a845d50a8/flake.nix). Feel free to clone that commit and run
`nix develop --impure`