### PR TITLE
Fix motoko build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,8 +8,8 @@ let
         targets = [ "wasm32-unknown-unknown" ];
         extensions = [ "rust-src" ];
       };
-      rust-nightly = self.rust-bin.nightly."2024-07-28".default.override {
-        targets = [ "wasm32-unknown-emscripten" "wasm32-wasi" ];
+      rust-nightly = self.rust-bin.nightly."2024-10-17".default.override {
+        targets = [ "wasm32-wasip1" ];
         extensions = [ "rust-src" ];
       };
       v8 = self.v8_8_x;

--- a/nix/cargo-vendor-tools.patch
+++ b/nix/cargo-vendor-tools.patch
@@ -1,0 +1,13 @@
+diff --git a/src/vendor_rust_std_deps.rs b/src/vendor_rust_std_deps.rs
+index 3c3bf7e78..634ccdd31 100644
+--- a/src/vendor_rust_std_deps.rs
++++ b/src/vendor_rust_std_deps.rs
+@@ -34,7 +34,7 @@ fn main() {
+ 
+     let compiler_cargo_lock_path = format!(
+         "{}/{}",
+-        rust_install_path, "lib/rustlib/src/rust/Cargo.lock"
++        rust_install_path, "lib/rustlib/src/rust/library/Cargo.lock"
+     );
+ 
+     println!("Reading compiler Cargo.lock ...");

--- a/nix/motoko-rts.patch
+++ b/nix/motoko-rts.patch
@@ -1,0 +1,12 @@
+diff --git a/motoko-rts/src/lib.rs b/motoko-rts/src/lib.rs
+index 615c9c318..dddeeacb6 100644
+--- a/motoko-rts/src/lib.rs
++++ b/motoko-rts/src/lib.rs
+@@ -2,6 +2,7 @@
+ 
+ #![no_std]
+ #![feature(
++    arbitrary_self_types_pointers,
+     arbitrary_self_types,
+     core_intrinsics,
+     proc_macro_hygiene,


### PR DESCRIPTION
The latest rust-bindgen seems to break motoko-rts build. It is fixed by switching to a newer version of rust nightly and applying necessary patches.